### PR TITLE
排他投票制御のパフォーマンスを改善

### DIFF
--- a/dist/bot/listeners/judge.js
+++ b/dist/bot/listeners/judge.js
@@ -34,18 +34,22 @@ var Judge;
         })
             .on('channelDelete', channel => {
             cache.deleteChannel(channel);
+        })
+            .on('guildDelete', guild => {
+            guild.channels.cache.each(channel => cache.deleteChannel(channel));
         });
     }
     Judge.initialize = initialize;
     async function regulateAddVote(bot, reaction, user) {
         if (user.id === bot.user.id)
             return;
-        const message = await reaction.message.fetch();
+        const message = await reaction.message.fetch(false);
         if (!isPollMessage(bot, message)) {
             utils_1.Utils.removeMessageCache(message);
             return;
         }
-        const refreshedReaction = message.reactions.cache.get(VoteCache_1.VoteCache.toEmojiId(reaction.emoji));
+        const reactionEmojiId = VoteCache_1.VoteCache.toEmojiId(reaction.emoji);
+        const refreshedReaction = message.reactions.cache.get(reactionEmojiId);
         if (!refreshedReaction)
             return;
         reaction = refreshedReaction;
@@ -56,19 +60,18 @@ var Judge;
         if (!isExPoll(message))
             return;
         const lastReactionEmojiId = cache.get(message.channelId, message.id, user.id);
-        cache.set(message.channelId, message.id, user.id, VoteCache_1.VoteCache.toEmojiId(reaction.emoji));
+        cache.set(message.channelId, message.id, user.id, reactionEmojiId);
         if (lastReactionEmojiId === null)
             return;
         if (lastReactionEmojiId === undefined)
             await removeOtherReactions(message, user, reaction.emoji.identifier);
         else
-            await message.reactions.cache.get(lastReactionEmojiId)
-                ?.users.remove(user.id);
+            await message.reactions.cache.get(lastReactionEmojiId)?.users.remove(user.id);
     }
     async function regulateRemoveVote(bot, reaction, user) {
         if (user.id === bot.user.id)
             return;
-        const message = await reaction.message.fetch();
+        const message = await reaction.message.fetch(false);
         if (!isPollMessage(bot, message)) {
             utils_1.Utils.removeMessageCache(message);
             return;
@@ -77,7 +80,7 @@ var Judge;
         if (!isExPoll(message)) {
             if (!isFreePoll(message) && lastReactionEmojiId === undefined) {
                 cache.clear(message.channelId, message.id, user.id);
-                await removeOutsideReactions(message, user, reaction.emoji.identifier);
+                await removeOutsideReactions(message, reaction.emoji.identifier);
             }
             return;
         }
@@ -98,14 +101,20 @@ var Judge;
     function isFreePoll(message) {
         return !message.reactions.cache.some(reaction => reaction.me);
     }
-    function removeOtherReactions(message, user, excludeEmojiIdentifier) {
-        return Promise.all(message.reactions.cache
-            .filter(reaction => reaction.emoji.identifier !== excludeEmojiIdentifier)
-            .map(reaction => reaction.users.remove(user.id)));
+    async function removeOtherReactions(message, user, excludeEmojiIdentifier) {
+        const reactions = message.reactions.cache
+            .filter(reaction => reaction.me && reaction.emoji.identifier !== excludeEmojiIdentifier);
+        const removedReactions = await removeOutsideReactions(message, excludeEmojiIdentifier);
+        for (const reaction of reactions.values()) {
+            if (VoteCache_1.VoteCache.toEmojiId(reaction.emoji) === cache.get(message.channelId, message.id, user.id))
+                continue;
+            removedReactions.push(await reaction.users.remove(user.id));
+        }
+        return removedReactions;
     }
-    function removeOutsideReactions(message, user, excludeEmojiIdentifier) {
+    function removeOutsideReactions(message, excludeEmojiIdentifier) {
         return Promise.all(message.reactions.cache
             .filter(reaction => !reaction.me && reaction.emoji.identifier !== excludeEmojiIdentifier)
-            .map(reaction => reaction.users.remove(user.id)));
+            .map(reaction => reaction.remove()));
     }
 })(Judge = exports.Judge || (exports.Judge = {}));

--- a/dist/bot/listeners/judge.js
+++ b/dist/bot/listeners/judge.js
@@ -61,11 +61,11 @@ var Judge;
             return;
         const lastReactionEmojiId = cache.get(message.channelId, message.id, user.id);
         cache.set(message.channelId, message.id, user.id, reactionEmojiId);
-        if (lastReactionEmojiId === null)
-            return;
-        if (lastReactionEmojiId === undefined)
-            await removeOtherReactions(message, user, reaction.emoji.identifier);
-        else
+        if (lastReactionEmojiId === undefined) {
+            // if (isCompletedReactions(message)) return;
+            await removeOtherReactions(message, user, reaction.emoji);
+        }
+        if (lastReactionEmojiId)
             await message.reactions.cache.get(lastReactionEmojiId)?.users.remove(user.id);
     }
     async function regulateRemoveVote(bot, reaction, user) {
@@ -76,20 +76,18 @@ var Judge;
             utils_1.Utils.removeMessageCache(message);
             return;
         }
-        const lastReactionEmojiId = cache.get(message.channelId, message.id, user.id);
         if (!isExPoll(message)) {
-            if (!isFreePoll(message) && lastReactionEmojiId === undefined) {
-                cache.clear(message.channelId, message.id, user.id);
-                await removeOutsideReactions(message, reaction.emoji.identifier);
-            }
+            if (!isFreePoll(message))
+                await removeOutsideReactions(message, reaction.emoji);
             return;
         }
-        if (lastReactionEmojiId !== undefined
-            && VoteCache_1.VoteCache.toEmojiId(reaction.emoji) !== lastReactionEmojiId)
-            return;
-        cache.clear(message.channelId, message.id, user.id);
-        if (lastReactionEmojiId === undefined)
-            await removeOtherReactions(message, user, reaction.emoji.identifier);
+        const lastReactionEmojiId = cache.get(message.channelId, message.id, user.id);
+        if (lastReactionEmojiId === undefined) {
+            cache.clear(message.channelId, message.id, user.id);
+            await removeOtherReactions(message, user, reaction.emoji);
+        }
+        else if (VoteCache_1.VoteCache.toEmojiId(reaction.emoji) === lastReactionEmojiId)
+            cache.clear(message.channelId, message.id, user.id);
     }
     function isPollMessage(bot, message) {
         return message.author.id === bot.user.id
@@ -101,10 +99,14 @@ var Judge;
     function isFreePoll(message) {
         return !message.reactions.cache.some(reaction => reaction.me);
     }
-    async function removeOtherReactions(message, user, excludeEmojiIdentifier) {
+    // MessageReaction needs to be modified on the discord.js side.
+    // function isCompletedReactions(message: Message): boolean {
+    //   return !message.reactions.cache.some(reaction => reaction.count !== reaction.users.cache.size);
+    // }
+    async function removeOtherReactions(message, user, excludeEmoji) {
         const reactions = message.reactions.cache
-            .filter(reaction => reaction.me && reaction.emoji.identifier !== excludeEmojiIdentifier);
-        const removedReactions = await removeOutsideReactions(message, excludeEmojiIdentifier);
+            .filter(reaction => reaction.me && reaction.emoji.identifier !== excludeEmoji.identifier);
+        const removedReactions = await removeOutsideReactions(message, excludeEmoji);
         for (const reaction of reactions.values()) {
             if (VoteCache_1.VoteCache.toEmojiId(reaction.emoji) === cache.get(message.channelId, message.id, user.id))
                 continue;
@@ -112,9 +114,9 @@ var Judge;
         }
         return removedReactions;
     }
-    function removeOutsideReactions(message, excludeEmojiIdentifier) {
+    function removeOutsideReactions(message, excludeEmoji) {
         return Promise.all(message.reactions.cache
-            .filter(reaction => !reaction.me && reaction.emoji.identifier !== excludeEmojiIdentifier)
+            .filter(reaction => !reaction.me && reaction.emoji.identifier !== excludeEmoji.identifier)
             .map(reaction => reaction.remove()));
     }
 })(Judge = exports.Judge || (exports.Judge = {}));

--- a/src/bot/listeners/judge.ts
+++ b/src/bot/listeners/judge.ts
@@ -9,7 +9,7 @@ import type {
   PartialMessageReaction,
   PartialUser,
   User,
-  Snowflake,
+  Emoji,
 } from 'discord.js';;
 
 type RoughUser = User | PartialUser;
@@ -20,7 +20,6 @@ export namespace Judge {
 
   export function adjustCache(message: Message): false {
     cache.deleteMessage(message)
-
     return false;
   }
 
@@ -77,11 +76,12 @@ export namespace Judge {
     const lastReactionEmojiId = cache.get(message.channelId, message.id, user.id);
     cache.set(message.channelId, message.id, user.id, reactionEmojiId);
 
-    if (lastReactionEmojiId === null) return;
+    if (lastReactionEmojiId === undefined) {
+      // if (isCompletedReactions(message)) return;
+      await removeOtherReactions(message, user, reaction.emoji);
+    }
 
-    if (lastReactionEmojiId === undefined)
-      await removeOtherReactions(message, user, reaction.emoji.identifier);
-    else
+    if (lastReactionEmojiId)
       await message.reactions.cache.get(lastReactionEmojiId)?.users.remove(user.id);
   }
 
@@ -96,25 +96,19 @@ export namespace Judge {
       return;
     }
 
-    const lastReactionEmojiId = cache.get(message.channelId, message.id, user.id);
-
     if (!isExPoll(message)) {
-      if (!isFreePoll(message) && lastReactionEmojiId === undefined) {
-        cache.clear(message.channelId, message.id, user.id);
-        await removeOutsideReactions(message, reaction.emoji.identifier);
-      }
+      if (!isFreePoll(message)) await removeOutsideReactions(message, reaction.emoji);
       return;
     }
 
-    if (
-      lastReactionEmojiId !== undefined
-        && VoteCache.toEmojiId(reaction.emoji) !== lastReactionEmojiId
-    ) return;
-
-    cache.clear(message.channelId, message.id, user.id);
-
-    if (lastReactionEmojiId === undefined)
-      await removeOtherReactions(message, user, reaction.emoji.identifier);
+    const lastReactionEmojiId = cache.get(message.channelId, message.id, user.id);
+    if (lastReactionEmojiId === undefined) {
+      cache.clear(message.channelId, message.id, user.id);
+      await removeOtherReactions(message, user, reaction.emoji);
+    }
+    else
+      if (VoteCache.toEmojiId(reaction.emoji) === lastReactionEmojiId)
+        cache.clear(message.channelId, message.id, user.id);
   }
 
   function isPollMessage(bot: Client<true>, message: Message): boolean {
@@ -130,12 +124,17 @@ export namespace Judge {
     return !message.reactions.cache.some(reaction => reaction.me);
   }
 
+  // MessageReaction needs to be modified on the discord.js side.
+  // function isCompletedReactions(message: Message): boolean {
+  //   return !message.reactions.cache.some(reaction => reaction.count !== reaction.users.cache.size);
+  // }
+
   async function removeOtherReactions(
-    message: Message, user: RoughUser, excludeEmojiIdentifier: Snowflake | string
+    message: Message, user: RoughUser, excludeEmoji: Emoji
   ): Promise<MessageReaction[]> {
     const reactions = message.reactions.cache
-      .filter(reaction => reaction.me && reaction.emoji.identifier !== excludeEmojiIdentifier);
-    const removedReactions = await removeOutsideReactions(message, excludeEmojiIdentifier);
+      .filter(reaction => reaction.me && reaction.emoji.identifier !== excludeEmoji.identifier);
+    const removedReactions = await removeOutsideReactions(message, excludeEmoji);
 
     for (const reaction of reactions.values()) {
       if (VoteCache.toEmojiId(reaction.emoji) === cache.get(message.channelId, message.id, user.id))
@@ -148,11 +147,11 @@ export namespace Judge {
   }
 
   function removeOutsideReactions(
-    message: Message, excludeEmojiIdentifier: Snowflake | string
+    message: Message, excludeEmoji: Emoji
   ): Promise<MessageReaction[]> {
     return Promise.all(
       message.reactions.cache
-        .filter(reaction => !reaction.me && reaction.emoji.identifier !== excludeEmojiIdentifier)
+        .filter(reaction => !reaction.me && reaction.emoji.identifier !== excludeEmoji.identifier)
         .map(reaction => reaction.remove())
     );
   }


### PR DESCRIPTION
- Messageの強制フェッチを無効化
- ギルド削除に伴い関連キャッシュも削除
- 未キャッシュ状態での投票制御を改善
- 選択肢外リアクションにおいて全ユーザーのリアクションを削除