### PR TITLE
予期しないリアクションイベントへの対応

### DIFF
--- a/dist/bot/listeners/VoteTracer.js
+++ b/dist/bot/listeners/VoteTracer.js
@@ -1,21 +1,21 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.VoteCache = void 0;
+exports.VoteTracer = void 0;
 const discord_js_1 = require("discord.js");
-class VoteCache {
+class VoteTracer {
     constructor() {
-        this.cache = new discord_js_1.Collection();
+        this.trace = new discord_js_1.Collection();
     }
     static toEmojiId(emoji) {
         return emoji.id ?? emoji.name ?? '';
     }
     get(channelId, messageId, userId) {
-        const messages = this.cache.get(channelId);
+        const messages = this.trace.get(channelId);
         const users = messages?.get(messageId);
         return users?.get(userId);
     }
     set(channelId, messageId, userId, emojiId) {
-        let messages = this.cache.get(channelId);
+        let messages = this.trace.get(channelId);
         let users = messages?.get(messageId);
         if (users)
             users.set(userId, emojiId);
@@ -25,7 +25,7 @@ class VoteCache {
                 messages.set(messageId, users);
             else {
                 messages = new discord_js_1.Collection([[messageId, users]]);
-                this.cache.set(channelId, messages);
+                this.trace.set(channelId, messages);
             }
         }
         return this;
@@ -34,7 +34,7 @@ class VoteCache {
         return this.set(channelId, messageId, userId, null);
     }
     clearEmoji(message, emojiId) {
-        const messages = this.cache.get(message.channelId);
+        const messages = this.trace.get(message.channelId);
         let users = messages?.get(message.id);
         if (!messages || !users)
             return;
@@ -42,19 +42,19 @@ class VoteCache {
         messages.set(message.id, users);
     }
     delete(channelId, messageId, userId) {
-        return this.cache
+        return this.trace
             .get(channelId)
             ?.get(messageId)
             ?.delete(userId) ?? false;
     }
     deleteChannel(channel) {
-        return this.cache
+        return this.trace
             .delete(channel.id);
     }
     deleteMessage(message) {
-        return this.cache
+        return this.trace
             .get(message.channelId)
             ?.delete(message.id) ?? false;
     }
 }
-exports.VoteCache = VoteCache;
+exports.VoteTracer = VoteTracer;

--- a/dist/bot/listeners/judge.js
+++ b/dist/bot/listeners/judge.js
@@ -64,6 +64,7 @@ var Judge;
             return;
         const lastReactionEmojiId = tracer.get(message.channelId, message.id, user.id);
         tracer.set(message.channelId, message.id, user.id, reactionEmojiId);
+        console.log(`add:${lastReactionEmojiId}`);
         switch (lastReactionEmojiId) {
             case undefined:
                 if (isGraspedReactions(message))
@@ -94,15 +95,15 @@ var Judge;
             return;
         }
         const lastReactionEmojiId = tracer.get(message.channelId, message.id, user.id);
+        console.log(`remove:${lastReactionEmojiId}`);
         switch (lastReactionEmojiId) {
-            case VoteTracer_1.VoteTracer.toEmojiId(reaction.emoji):
-                tracer.clear(message.channelId, message.id, user.id);
-            case null:
-                break;
             case undefined:
-            default:
                 tracer.clear(message.channelId, message.id, user.id);
                 await removeOtherReactions(message, user, reaction.emoji);
+                break;
+            case VoteTracer_1.VoteTracer.toEmojiId(reaction.emoji):
+                tracer.clear(message.channelId, message.id, user.id);
+            default:
         }
     }
     function isPollMessage(bot, message) {

--- a/src/bot/listeners/judge.ts
+++ b/src/bot/listeners/judge.ts
@@ -81,6 +81,7 @@ export namespace Judge {
     const lastReactionEmojiId = tracer.get(message.channelId, message.id, user.id);
     tracer.set(message.channelId, message.id, user.id, reactionEmojiId);
 
+    console.log(`add:${lastReactionEmojiId}`);
     switch (lastReactionEmojiId) {
       case undefined:
         if (isGraspedReactions(message)) break;
@@ -116,15 +117,15 @@ export namespace Judge {
 
     const lastReactionEmojiId = tracer.get(message.channelId, message.id, user.id);
 
+    console.log(`remove:${lastReactionEmojiId}`);
     switch (lastReactionEmojiId) {
-      case VoteTracer.toEmojiId(reaction.emoji):
-        tracer.clear(message.channelId, message.id, user.id);
-      case null:
-        break;
       case undefined:
-      default:
         tracer.clear(message.channelId, message.id, user.id);
         await removeOtherReactions(message, user, reaction.emoji);
+        break;
+      case VoteTracer.toEmojiId(reaction.emoji):
+        tracer.clear(message.channelId, message.id, user.id);
+      default:
     }
   }
 


### PR DESCRIPTION
クリアリング済みの投票で発生する、以下のような予期しないリアクションイベントに対応する。
- 既に投票されたリアクションに、再び同じリアクションが押された
- 投票されているリアクション以外のリアクションが削除された

この場合、クリアリングをもう1度実施する。